### PR TITLE
add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:alpine3.17 AS build-env
+
+RUN apk add --update cargo
+
+COPY . key-convertr/
+
+RUN cargo install --path key-convertr --root /usr/local/bin
+
+FROM alpine:3.17
+
+COPY --from=build-env /usr/local/bin/* /usr/local/bin/
+
+WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/key-convertr"]


### PR DESCRIPTION
if you have docker running already, there is no need to set up a rust dev environment to use the tool. Just use the docker image instead
```
➜  docker-key-converter git:(main) docker run --rm aphex3k/key-convertr:testing --help                                                                                                                 
Usage: key-convertr [OPTIONS] <KEY>

Arguments:
  <KEY>  the key or note id that you want to convert

Options:
  -k, --kind <KIND>  the kind of entity you are converting [possible values: npub, nsec, note]
      --to-hex       you want to convert from bech32 to hex
  -h, --help         Print help information
  -V, --version      Print version information
```