### PR TITLE
Create GitHub Actions for CI and release built binaries

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,17 @@
+name: clippy
+on: [push, pull_request]
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -4,12 +4,12 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            components: clippy
-            override: true
+          toolchain: stable
+          components: clippy
+          override: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -1,0 +1,162 @@
+name: Mean Bean CI
+
+on: [push, pull_request]
+
+jobs:
+  install-cross:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - uses: XAMPPRocky/get-github-release@v1
+        id: cross
+        with:
+          owner: rust-embedded
+          repo: cross
+          matches: ${{ matrix.platform }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cross-${{ matrix.platform }}
+          path: ${{ steps.cross.outputs.install_path }}
+    strategy:
+      matrix:
+        platform: [linux-musl]
+
+  windows:
+    runs-on: windows-latest
+    # Windows technically doesn't need this, but if we don't block windows on it
+    # some of the windows jobs could fill up the concurrent job queue before
+    # one of the install-cross jobs has started, so this makes sure all
+    # artifacts are downloaded first.
+    needs: install-cross
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+        shell: bash
+      - run: ci/build.bash cargo ${{ matrix.target }}
+        shell: bash
+      - run: ci/test.bash cargo ${{ matrix.target }}
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable, beta, nightly]
+        target:
+          # MSVC
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          # GNU: You typically only need to test Windows GNU if you're
+          # specifically targetting it, and it can cause issues with some
+          # dependencies if you're not so it's disabled by self.
+          # - i686-pc-windows-gnu
+          # - x86_64-pc-windows-gnu
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable, beta, nightly]
+        target:
+          - x86_64-apple-darwin
+          ### Disable running tests on M1 target, not currently working
+          ###
+          #- aarch64-apple-darwin
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{ matrix.target }}
+
+  linux:
+    runs-on: ubuntu-latest
+    needs: install-cross
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+
+      - name: Download Cross
+        uses: actions/download-artifact@v1
+        with:
+          name: cross-linux-musl
+          path: /tmp/
+      - run: chmod +x /tmp/cross
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+      - run: ci/build.bash /tmp/cross ${{ matrix.target }}
+        # These targets have issues with being tested so they are disabled
+        # by default. You can try disabling to see if they work for
+        # your project.
+      - run: ci/test.bash /tmp/cross ${{ matrix.target }}
+        if: |
+          !contains(matrix.target, 'android') &&
+          !contains(matrix.target, 'bsd') &&
+          !contains(matrix.target, 'solaris') &&
+          matrix.target != 'armv5te-unknown-linux-musleabi' &&
+          matrix.target != 'sparc64-unknown-linux-gnu'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable, beta, nightly]
+        target:
+          # WASM, off by default as most rust projects aren't compatible yet.
+          # - wasm32-unknown-emscripten
+          # Linux
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          # - i686-unknown-linux-gnu
+          # - mips-unknown-linux-gnu
+          # - mips64-unknown-linux-gnuabi64
+          # - mips64el-unknown-linux-gnuabi64
+          # - mipsel-unknown-linux-gnu
+          # - powerpc-unknown-linux-gnu
+          # - powerpc64-unknown-linux-gnu
+          # - s390x-unknown-linux-gnu
+          # - x86_64-unknown-linux-gnu
+          ## Android
+          # - aarch64-linux-android
+          # - arm-linux-androideabi
+          # - armv7-linux-androideabi
+          # - i686-linux-android
+          # - x86_64-linux-android
+          ## *BSD
+          # The FreeBSD targets can have issues linking so they are disabled
+          # by default.
+          # - i686-unknown-freebsd
+          # - x86_64-unknown-freebsd
+          # - x86_64-unknown-netbsd
+          ## Solaris
+          # - sparcv9-sun-solaris
+          ## Bare Metal
+          # These are no-std embedded targets, so they will only build if your
+          # crate is `no_std` compatible.
+          # - thumbv6m-none-eabi
+          # - thumbv7em-none-eabi
+          # - thumbv7em-none-eabihf
+          # - thumbv7m-none-eabi

--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -6,7 +6,7 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - uses: XAMPPRocky/get-github-release@v1

--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -16,7 +16,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 50
 
       - name: Download Cross
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: cross-linux-musl
           path: /tmp/

--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -16,7 +16,7 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - uses: XAMPPRocky/get-github-release@v1

--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -1,0 +1,232 @@
+on:
+  push:
+    # # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Mean Bean Deploy
+env:
+  BIN: key-convertr
+
+jobs:
+  # This job downloads and stores `cross` as an artifact, so that it can be
+  # redownloaded across all of the jobs. Currently this copied pasted between
+  # `mean_bean_ci.yml` and `mean_bean_deploy.yml`. Make sure to update both places when making
+  # changes.
+  install-cross:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - uses: XAMPPRocky/get-github-release@v1
+        id: cross
+        with:
+          owner: rust-embedded
+          repo: cross
+          matches: ${{ matrix.platform }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cross-${{ matrix.platform }}
+          path: ${{ steps.cross.outputs.install_path }}
+    strategy:
+      matrix:
+        platform: [linux-musl]
+
+  windows:
+    runs-on: windows-latest
+    needs: install-cross
+    strategy:
+      matrix:
+        target:
+          # MSVC
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          # GNU
+          # - i686-pc-windows-gnu
+          # - x86_64-pc-windows-gnu
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - uses: actions/checkout@v3
+      - run: bash ci/set_rust_version.bash stable ${{ matrix.target }}
+      - run: bash ci/build.bash cargo ${{ matrix.target }} RELEASE
+      - run: |
+          cd ./target/${{ matrix.target }}/release/
+          7z a "${{ env.BIN }}.zip" "${{ env.BIN }}.exe"
+          mv "${{ env.BIN }}.zip" $GITHUB_WORKSPACE
+        shell: bash
+        # We're using using a fork of `actions/create-release` that detects
+        # whether a release is already available or not first.
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          # Draft should **always** be false. GitHub doesn't provide a way to
+          # get draft releases from its API, so there's no point using it.
+          draft: false
+          prerelease: false
+      - uses: actions/upload-release-asset@v1
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.zip
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
+          asset_content_type: application/zip
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          # macOS
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+          # iOS
+          # - aarch64-apple-ios
+          # - armv7-apple-ios
+          # - armv7s-apple-ios
+          # - i386-apple-ios
+          # - x86_64-apple-ios
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: Setup | Checkout
+        uses: actions/checkout@v3
+
+      # Cache files between builds
+      - name: Setup | Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+
+      - name: Build | Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.tar.gz
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+
+  linux:
+    runs-on: ubuntu-latest
+    needs: install-cross
+    strategy:
+      matrix:
+        target:
+          ## WASM, off by default as most rust projects aren't compatible yet.
+          # - wasm32-unknown-emscripten
+          ## Linux
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          # - i686-unknown-linux-gnu
+          # - mips-unknown-linux-gnu
+          # - mips64-unknown-linux-gnuabi64
+          # - mips64el-unknown-linux-gnuabi64
+          # - mipsel-unknown-linux-gnu
+          # - powerpc-unknown-linux-gnu
+          # - powerpc64-unknown-linux-gnu
+          # - s390x-unknown-linux-gnu
+          # - x86_64-unknown-linux-gnu
+          ## Android
+          # - aarch64-linux-android
+          # - arm-linux-androideabi
+          # - armv7-linux-androideabi
+          # - i686-linux-android
+          # - x86_64-linux-android
+          ## *BSD
+          # The FreeBSD targets can have issues linking so they are disabled
+          # by default.
+          # - i686-unknown-freebsd
+          # - x86_64-unknown-freebsd
+          # - x86_64-unknown-netbsd
+          ## Solaris
+          # - sparcv9-sun-solaris
+          ## Bare Metal
+          # These are no-std embedded targets, so they will only build if your
+          # crate is `no_std` compatible.
+          # - thumbv6m-none-eabi
+          # - thumbv7em-none-eabi
+          # - thumbv7em-none-eabihf
+          # - thumbv7m-none-eabi
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v1
+        with:
+          name: cross-linux-musl
+          path: /tmp/
+      - run: chmod +x /tmp/cross
+
+      - run: ci/set_rust_version.bash stable ${{ matrix.target }}
+      - run: ci/build.bash /tmp/cross ${{ matrix.target }} RELEASE
+      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.tar.gz
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   # This job downloads and stores `cross` as an artifact, so that it can be
-  # redownloaded across all of the jobs. Currently this copied pasted between
+  # re-downloaded across all of the jobs. Currently this copied pasted between
   # `mean_bean_ci.yml` and `mean_bean_deploy.yml`. Make sure to update both places when making
   # changes.
   install-cross:
@@ -26,7 +26,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -202,7 +202,7 @@ jobs:
         uses: dawidd6/action-get-tag@v1
 
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: cross-linux-musl
           path: /tmp/

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,18 @@
+# When pushed to master, run `cargo +nightly fmt --all` and open a PR.
+name: rustfmt
+on: [push, pull_request]
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain with rustfmt available
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - run: rustfmt --edition 2021 **/*.rs --check

--- a/ci/build.bash
+++ b/ci/build.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Script for building your rust projects.
+set -e
+
+source ci/common.bash
+
+# $1 {path} = Path to cross/cargo executable
+CROSS=$1
+# $1 {string} = <Target Triple> e.g. x86_64-pc-windows-msvc
+TARGET_TRIPLE=$2
+# $3 {boolean} = Are we building for deployment? 
+RELEASE_BUILD=$3
+
+required_arg $CROSS 'CROSS'
+required_arg $TARGET_TRIPLE '<Target Triple>'
+
+if [ -z "$RELEASE_BUILD" ]; then
+    $CROSS build --target $TARGET_TRIPLE
+    $CROSS build --target $TARGET_TRIPLE --all-features
+else
+    $CROSS build --target $TARGET_TRIPLE --all-features --release
+fi
+

--- a/ci/common.bash
+++ b/ci/common.bash
@@ -1,0 +1,6 @@
+required_arg() {
+    if [ -z "$1" ]; then
+        echo "Required argument $2 missing"
+        exit 1
+    fi
+}

--- a/ci/set_rust_version.bash
+++ b/ci/set_rust_version.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+rustup default $1
+rustup target add $2

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Script for building your rust projects.
+set -e
+
+source ci/common.bash
+
+# $1 {path} = Path to cross/cargo executable
+CROSS=$1
+# $1 {string} = <Target Triple>
+TARGET_TRIPLE=$2
+
+required_arg $CROSS 'CROSS'
+required_arg $TARGET_TRIPLE '<Target Triple>'
+
+$CROSS test --target $TARGET_TRIPLE
+$CROSS test --target $TARGET_TRIPLE --all-features

--- a/install.sh
+++ b/install.sh
@@ -121,7 +121,7 @@ fi
 url="$url/releases"
 
 if [ -z "$tag" ]; then
-    tag=$(curl -s "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    tag=$(curl "https://api.github.com/repos/$git/releases/latest" | grep "tag_name" | cut -d'"' -f4)
     say_err "Tag: latest ($tag)"
 else
     say_err "Tag: $tag"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+# Heavily modified from https://github.com/japaric/trust/blob/gh-pages/install.sh.
+
+help() {
+    cat <<'EOF'
+Install a binary release of a Rust crate hosted on GitHub.
+
+Usage:
+    install.sh [options]
+
+Options:
+    -h, --help      Display this message
+    --git SLUG      Get the crate from "https://github/$SLUG"
+    -f, --force     Force overwriting an existing binary
+    --crate NAME    Name of the crate to install (default <repository name>)
+    --tag TAG       Tag (version) of the crate to install (default <latest release>)
+    --to LOCATION   Where to install the binary (default /usr/local/bin)
+EOF
+}
+
+say() {
+    echo "install.sh: $1"
+}
+
+say_err() {
+    say "$1" >&2
+}
+
+err() {
+    if [ -n "$td" ]; then
+        rm -rf "$td"
+    fi
+
+    say_err "ERROR $1"
+    exit 1
+}
+
+need() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        err "need $1 (command not found)"
+    fi
+}
+
+force=false
+while test $# -gt 0; do
+    case $1 in
+        --crate)
+            crate=$2
+            shift
+            ;;
+        --force | -f)
+            force=true
+            ;;
+        --git)
+            git=$2
+            shift
+            ;;
+        --help | -h)
+            help
+            exit 0
+            ;;
+        --tag)
+            tag=$2
+            shift
+            ;;
+        --to)
+            dest=$2
+            shift
+            ;;
+        *)
+            ;;
+    esac
+    shift
+done
+
+# Dependencies
+need basename
+need curl
+need install
+need mkdir
+need mktemp
+need tar
+
+# Optional dependencies
+if [ -z "$crate" ] || [ -z "$tag" ] || [ -z "$target" ]; then
+    need cut
+fi
+
+if [ -z "$tag" ]; then
+    need rev
+fi
+
+if [ -z "$git" ]; then
+    # shellcheck disable=SC2016
+    err 'must specify a git repository using `--git`. Example: `install.sh --git japaric/cross`'
+fi
+
+url="https://github.com/$git"
+
+if [ "$(curl --head --write-out "%{http_code}\n" --silent --output /dev/null "$url")" -eq "404" ]; then
+  err "GitHub repository $git does not exist"
+fi
+
+say_err "GitHub repository: $url"
+
+if [ -z "$crate" ]; then
+    crate=$(echo "$git" | cut -d'/' -f2)
+fi
+
+say_err "Crate: $crate"
+
+if [ -z "$dest" ]; then
+    dest="/usr/local/bin"
+fi
+
+if [ -e "$dest/$crate" ] && [ $force = false ]; then
+    err "$crate already exists in $dest, use --force to overwrite the existing binary"
+fi
+
+url="$url/releases"
+
+if [ -z "$tag" ]; then
+    tag=$(curl -s "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    say_err "Tag: latest ($tag)"
+else
+    say_err "Tag: $tag"
+fi
+
+
+case "$(uname -s)" in
+"Darwin")
+  case "$(uname -m)" in
+    "x86_64")
+      target="x86_64-apple-darwin"
+      ;;
+    "arm64")
+      target="aarch64-apple-darwin"
+      ;;
+  esac
+  ;;
+"Linux")
+  platform="unknown-linux-musl"
+  target="$(uname -m)-$platform"
+  ;;
+esac
+
+say_err "Target: $target"
+
+url="$url/download/$tag/$crate-$tag-$target.tar.gz"
+
+say_err "Downloading: $url"
+
+if [ "$(curl --head --write-out "%{http_code}\n" --silent --output /dev/null "$url")" -eq "404" ]; then
+  err "$url does not exist, you will need to build $crate from source"
+fi
+
+td=$(mktemp -d || mktemp -d -t tmp)
+curl -sL "$url" | tar -C "$td" -xz
+
+say_err "Installing to: $dest"
+
+for f in "$td"/*; do
+    [ -e "$f" ] || break # handle the case of no *.wav files
+
+    test -x "$f" || continue
+
+    if [ -e "$dest/$crate" ] && [ $force = false ]; then
+        err "$crate already exists in $dest"
+    else
+        mkdir -p "$dest"
+        cp "$f" "$dest"
+        chmod 0755 "$dest/$crate"
+    fi
+done
+
+rm -rf "$td"


### PR DESCRIPTION
This PR will:

* build binaries for a lot of platforms see it working: https://github.com/praveenperera/key-convertr/releases/tag/v0.0.2
* run cargo clippy
* run cargo fmt to make sure its formatted

And you users can install with the install.sh script example, just change the repos and link name if you add to readme

```
curl -LSfs https://raw.githubusercontent.com/praveenperera/key-convertr/github-actions/install.sh | sh -s -- --git praveenperera/key-convertr
```

