### PR TITLE
Allow comma separated input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,24 +34,33 @@ fn main() {
         return;
     }
 
+    println!(""); // create space between inputs/outputs
+
     if args.to_hex {
-        let (_, data, _) = bech32::decode(&args.key).expect("could not decode data");
-        println!("{}", hex::encode(Vec::<u8>::from_base32(&data).unwrap()));
+        // convert npub to hex (accepts comma separated list of npubs)
+        let split = args.key.as_str().trim_end().split(",");
+        for s in split {
+            let (_, data, _) = bech32::decode(s).expect("could not decode data");
+            println!("{}", hex::encode(Vec::<u8>::from_base32(&data).unwrap()));
+        }
     } else {
+        // convert hex to npub (accepts comma separated list of hex)
+        let split = args.key.as_str().trim_end().split(",");
         let hrp = match args.kind.unwrap() {
             Prefix::Npub => "npub",
             Prefix::Nsec => "nsec",
             Prefix::Note => "note",
         };
-
-        let encoded = bech32::encode(
-            hrp,
-            hex::decode(args.key)
-                .expect("could not decode provided kay/note")
-                .to_base32(),
-            Variant::Bech32,
-        )
-        .expect("Could not bech32-encode data");
-        println!("{}", encoded);
+        for s in split {
+            let encoded = bech32::encode(
+                hrp,
+                hex::decode(s)
+                    .expect("could not decode provided key/note")
+                    .to_base32(),
+                Variant::Bech32,
+            )
+            .expect("Could not bech32-encode data");
+            println!("{}", encoded);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,8 @@ struct Args {
     #[arg(long, help = "you want to convert from bech32 to hex")]
     to_hex: bool,
 
-    #[arg(help = "the key or note id that you want to convert")]
-    key: String,
+    #[arg(use_value_delimiter = true, value_delimiter = ',', help = "the key/s or note id/s that you want to convert")]
+    keys: Vec<String>,
 }
 
 fn main() {
@@ -36,20 +36,18 @@ fn main() {
 
     if args.to_hex {
         // convert npub to hex (accepts comma separated list of npubs)
-        let split = args.key.as_str().trim_end().split(',');
-        for s in split {
+        for s in &args.keys {
             let (_, data, _) = bech32::decode(s).expect("could not decode data");
             println!("{}", hex::encode(Vec::<u8>::from_base32(&data).unwrap()));
         }
     } else {
         // convert hex to npub (accepts comma separated list of hex)
-        let split = args.key.as_str().trim_end().split(',');
         let hrp = match args.kind.unwrap() {
             Prefix::Npub => "npub",
             Prefix::Nsec => "nsec",
             Prefix::Note => "note",
         };
-        for s in split {
+        for s in &args.keys {
             let encoded = bech32::encode(
                 hrp,
                 hex::decode(s)

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,6 @@ fn main() {
         return;
     }
 
-    println!(""); // create space between inputs/outputs
-
     if args.to_hex {
         // convert npub to hex (accepts comma separated list of npubs)
         let split = args.key.as_str().trim_end().split(",");

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,14 +36,14 @@ fn main() {
 
     if args.to_hex {
         // convert npub to hex (accepts comma separated list of npubs)
-        let split = args.key.as_str().trim_end().split(",");
+        let split = args.key.as_str().trim_end().split(',');
         for s in split {
             let (_, data, _) = bech32::decode(s).expect("could not decode data");
             println!("{}", hex::encode(Vec::<u8>::from_base32(&data).unwrap()));
         }
     } else {
         // convert hex to npub (accepts comma separated list of hex)
-        let split = args.key.as_str().trim_end().split(",");
+        let split = args.key.as_str().trim_end().split(',');
         let hrp = match args.kind.unwrap() {
             Prefix::Npub => "npub",
             Prefix::Nsec => "nsec",


### PR DESCRIPTION
## This change allows for multiple key/hex inputs at single shot (handy when dealing with nostr.json that has multiple values):
- removes trailing whitespace "trim_end()" from comma separated input string before splitting string by "," 
  - still works for input without comma separators
- then either encodes(--kind npub) or decodes(--to-hex) each key

### Before:
key-convertr --kind npub 89d1ce9164f1f172daaa9c784153178cb1dec7912bf55f5dc07e0f1dabe40e6c
key-convertr --to-hex npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k

### After:
key-convertr --kind npub 89d1ce9164f1f172daaa9c784153178cb1dec7912bf55f5dc07e0f1dabe40e6c,d987084c48390a290f5d2a34603ae64f55137d9b4affced8c0eae030eb222a25

key-convertr --to-hex npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k,npub1mxrssnzg8y9zjr6a9g6xqwhxfa23xlvmftluakxqatsrp6ez9gjssu0htc


![Encode](https://i.imgur.com/ByJeoWo.jpg)
![Decode](https://i.imgur.com/QA5Mx3i.jpg)

