### PR TITLE
[NIP5-identifiers] Add NIP-05 identifier converter method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "key-convertr"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bech32 = "0.9.1"
-clap = { version = "4.0.32", features = ["derive"] }
+clap = { version = "4.1.4", features = ["derive"] }
 hex = "0.4.3"
+reqwest = { version = "0.11.14", features = ["json"] }
+serde = { version = "1.0.152", features = ["derive"] }
+tokio = { version = "1.25.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bech32 = "0.9.1"
 clap = { version = "4.1.4", features = ["derive"] }
 hex = "0.4.3"
+regex = "1.7.1"
 reqwest = { version = "0.11.14", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 tokio = { version = "1.25.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 bech32 = "0.9.1"
 clap = { version = "4.1.4", features = ["derive"] }
 hex = "0.4.3"
-regex = "1.7.1"
-reqwest = { version = "0.11.14", features = ["json"] }
+regex = {version = "1.7.1", features = ["std", "unicode-case"], default-features = false}
+reqwest = { version = "0.11.14", features = ["json", "rustls-tls"], default-features=false }
+rustls = "0.20.8"
 serde = { version = "1.0.152", features = ["derive"] }
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Key-Convertr
+People are copy-pasting nostr private keys into webpages to convert between the original hex-encoding and bech32-encoding (specified in [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)).
 
-People are copy-pasting nostr private keys into webpages to convert between the original hex-encoding and bech32-encoding (specified in [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)). 
+This is kind of bonkers, so here's a command-line utility that you can run to convert public/private keys between hex-encoding and the NIP-19 bech32 encoding. It can also convert note id's, and even convert a list of public keys from NIP5 configured domains from hex to bech32 in single shot.
 
-This is kind of bonkers, so here's a command-line utility that you can run to convert public/private keys between hex-encoding and the NIP-19 bech32 encoding. IT can also convert note id's.
-
+## Features:
+>Note: "keys" + "nip5" arguments accept multiple inputs for bulk operations
+- convert from bech32 (npub/nsec/note) to hex
+- convert from hex to bech32 (npub/nsec/note)
+- supports NIP-05 domain identifiers:
+    - calls given nip5 domain to get nostr.json containing user pubkeys (located at domain.com/.well-known/nostr.json)
+    - extracts and converts all pubkeys from hex to bech32 format
+    - as specified in [NIP-05] (https://github.com/nostr-protocol/nips/blob/master/05.md)
+---
 ## Installation
 ### Building with Cargo
 If you have `cargo` installed, then from the `key-convertr` directory, just do `cargo install --path .`. It will put a program called `key-convertr` in your `$HOME/.cargo/bin` directory.
@@ -29,7 +37,7 @@ If you have docker installed, you can do `docker build -f docker/Dockerfile -t k
 $> docker run --rm key-convertr --kind npub 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
 npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6
 ```
-
+---
 ## Usage
 
 Just provide the hex-encoded key or note-id and a `--kind` argument. The `kind`s supported are:
@@ -37,16 +45,49 @@ Just provide the hex-encoded key or note-id and a `--kind` argument. The `kind`s
 - nsec
 - note
 
-To convert from an npub to hex-encoding, you can do
+To convert from an `bech32(npub/nsec/note) to hex-encoding`, you can do
 
 ```shell
 $> key-convertr --to-hex npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6
 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
 ```
 
-You can also pass multiple keys/notes to the tool by putting a comma or space between them. For example,
+To convert from an `hex-encoding to bech32 (npub/nsec/note)`, you can do
+
+```shell
+$> key-convertr --kind npub 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
+npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6
+```
+To convert list of public keys for a given `NIP-05 domain identifier`, you can
+```shell
+$> key-convertr --nip5 satoshivibes.com
+Aurelius,npub169yu4d6xl8a6d4xvfyhstjdxr0cc7qtfq5pch5kwv4k2wkapa3pq8v2thg
+frontrunbitcoin,npub199samvtne4sahhdkr6dcq3mauuqs7k7r3eulufp2y2lf04zewglqtu9mfd
+lukeonchain,npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k
+```
+- you can also enable NIP5 related stats via "--nip-stats" or "-s";
+    - this prints out summary stats in this format: `domain=SomeName.com|count=21`
+    - this output could then be parsed (if needed) by other dev tools/libraries
+```shell
+$> key-convertr --nip5 strike.me --nip-stats
+ZAurelius,npub169yu4d6xl8a6d4xvfyhstjdxr0cc7qtfq5pch5kwv4k2wkapa3pq8v2thg
+frontrunbitcoin,npub199samvtne4sahhdkr6dcq3mauuqs7k7r3eulufp2y2lf04zewglqtu9mfd
+lukeonchain,npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k
+domain=satoshivibes.com|count=3
+```
+
+You can also pass `multiple keys/notes` to the tool by putting a comma or space between them:
+- example with multiple "keys"
 ```shell
 $> key-convertr --kind npub 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d,863883611bdbe6291c081fb8775908a7ab0cb04b608405ec1e85e9f938020a98
 npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6
 npub1scugxcgmm0nzj8qgr7u8wkgg574sevztvzzqtmq7sh5ljwqzp2vqf45w5j
 ```
+- example with multiple NIP5 domains (output omitted due to size)
+```
+$> key-convertr --nip5 nostrplebs.com,strike.me,satoshivibes.com
+```
+---
+## TODO
+Optimizations:
+- multi threaded "--nip5" logic (multiple domains converted in parallel; some lists will be very large i.e nostrplebs.com)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,66 +1,145 @@
-use bech32::FromBase32;
-use bech32::{ToBase32, Variant};
-use clap::Parser;
+use bech32::{FromBase32, ToBase32, Variant};
+use clap::error::ErrorKind;
+use clap::{command, ArgGroup, CommandFactory, Parser};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
 
-#[derive(clap::ValueEnum, Clone, Debug)]
+#[derive(clap::ValueEnum, Clone, Debug, Copy)]
 enum Prefix {
     Npub,
     Nsec,
     Note,
 }
+// Display 'trait' needed for enum "to_string()"
+impl std::fmt::Display for Prefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Prefix::Npub => write!(f, "npub"),
+            Prefix::Nsec => write!(f, "nsec"),
+            Prefix::Note => write!(f, "note"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Nip5Id {
+    names: HashMap<String, String>,
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
+#[clap(group(
+    //  input error handling: only exactly ONE of 'n' args can be used
+    ArgGroup::new("convert_method")
+        .required(true)
+        .args(&["kind", "to_hex", "nip5"]),
+))]
 struct Args {
-    #[arg(short, long, help = "the kind of entity you are converting")]
+    #[arg(
+        short,
+        long,
+        help = "the kind of entity (npub/nsec/note) being converted from hex to bech32-formatted string",
+        requires = "keys"
+    )]
     kind: Option<Prefix>,
 
-    #[arg(long, help = "you want to convert from bech32 to hex")]
+    #[arg(
+        long,
+        help = "boolean flag indicating to convert keys from bech32 to hex",
+        requires = "keys"
+    )]
     to_hex: bool,
 
     #[arg(
         use_value_delimiter = true,
         value_delimiter = ',',
-        help = "the key/s or note id/s that you want to convert"
+        help = "the keys or note ids that you want to convert (either hex or bech32)"
     )]
     keys: Vec<String>,
+
+    #[arg(
+        long,
+        use_value_delimiter = true,
+        value_delimiter = ',',
+        help = "nip5 dns-based identifiers (domain names)"
+    )]
+    nip5: Option<Vec<String>>,
+
+    #[arg(
+        short = 's',
+        long,
+        requires = "nip5",
+        help = "nip5 identifiers stats logging"
+    )]
+    nip_stats: bool,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
-    if !args.to_hex && args.kind.is_none() {
-        println!("You need to either specify a `kind` of key you are converting (to go from hex to bech32) or specify `to-hex` (to go to hex)");
-        return;
-    }
-
-    if args.to_hex && args.kind.is_some() {
-        println!("provide either `--to-hex` OR a `--kind` to convert to. one or the other.");
-        return;
-    }
 
     if args.to_hex {
-        // convert npub to hex (accepts comma separated list of npubs)
+        // convert bech32 npub/nsec/note to hex (accepts list of bech32's)
         for s in &args.keys {
             let (_, data, _) = bech32::decode(s).expect("could not decode data");
             println!("{}", hex::encode(Vec::<u8>::from_base32(&data).unwrap()));
         }
-    } else {
-        // convert hex to npub (accepts comma separated list of hex)
-        let hrp = match args.kind.unwrap() {
-            Prefix::Npub => "npub",
-            Prefix::Nsec => "nsec",
-            Prefix::Note => "note",
-        };
-        for s in &args.keys {
-            let encoded = bech32::encode(
-                hrp,
-                hex::decode(s)
-                    .expect("could not decode provided key/note")
-                    .to_base32(),
-                Variant::Bech32,
-            )
-            .expect("Could not bech32-encode data");
-            println!("{}", encoded);
+    } else if args.kind.is_some() {
+        // convert hex to bech32 npub/nsec/note (accepts list of hex)
+        let hrp = args.kind.unwrap();
+        for key in &args.keys {
+            let encoded = bech32_encode(hrp, key);
+            println!("{encoded}");
         }
+    } else if args.nip5.is_some() {
+        for nip5_domain in &args.nip5.unwrap() {
+            let _result = fetch_nostr_json(nip5_domain.to_string()).await;
+            let nip5_ids: Nip5Id = _result.expect(
+                &("Error while fetching nostr.json from nip5-domain=".to_owned() + nip5_domain),
+            );
+            // using btreemap to keep things sorted by keys for final result
+            let mut map: BTreeMap<String, String> = BTreeMap::new();
+            for name in &nip5_ids.names {
+                map.insert(name.0.to_string(), bech32_encode(Prefix::Npub, name.1));
+            }
+            for (key, value) in &map {
+                println!("{key},{value}");
+            }
+            // optional flag based stats
+            if args.nip_stats {
+                println!("domain={}|count={}", nip5_domain, map.len());
+            }
+        }
+    } else {
+        Args::command() //  in the event of an args bug, this will print an error and exit
+            .error(
+                ErrorKind::MissingRequiredArgument,
+                "BUG!!! Should not get here, check input args/groups.",
+            )
+            .exit();
     }
+}
+
+/// Converts a hex encoded string to bech32 format for given a Prefix (hrp)
+fn bech32_encode(hrp: Prefix, hex_key: &String) -> String {
+    bech32::encode(
+        &hrp.to_string(),
+        hex::decode(hex_key)
+            .expect(&("could not decode provided key/note id=".to_owned() + hex_key))
+            .to_base32(),
+        Variant::Bech32,
+    )
+    .expect("Could not bech32-encode data")
+}
+
+/// Makes GET request to NIP-05 domain to get nostr.json, and converts public keys from hex to bech32 format
+async fn fetch_nostr_json(nip5_domain: String) -> Result<Nip5Id, reqwest::Error> {
+    let nip5_url = format!("{}{}{}", "https://", nip5_domain, "/.well-known/nostr.json");
+    let json: Nip5Id = reqwest::Client::new()
+        .get(nip5_url)
+        .send()
+        .await?
+        .json()
+        .await?;
+    Ok(json)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ async fn main() {
                 &("Error while fetching nostr.json from nip5-domain=".to_owned() + nip5_domain),
             );
             for (key, value) in &nip5_ids.names {
-                println!("{key},{value}");
+                println!("{key},{}", bech32_encode(Prefix::Npub, value));
             }
             // optional flag based stats
             if args.nip_stats {


### PR DESCRIPTION
### Adds NIP-05 identifier bulk converter support (https://github.com/nostr-protocol/nips/blob/master/05.md)

For each NIP5 domain name, fetches nostr.json and converts hex to bech32 npub equivalent.

### Change summary:
- adding new command option `"--nip5"`
- adding flag  `"--nip-stats"` or `"--s"` (using this flag requires already using `"--nip5"` option)
  - flag can be reused for future NIP related key-converting type features
- added clap parser requirements for proper error handling for "--to-hex" and "--kind" or "--nip5"
  - now both depend on "keys" (Vector<String>) and will throw appropriate error for "KEYS required"
- added clap parser "required" input error handling
- added clap's Error type in the final else, in case someone screws up the arguments logic in the future PRs (guarding against bad code)
- added new + updated dependencies
- updated README

### Usage
To convert list of public keys for a given `NIP-05 domain identifier`, you can
```shell
$> key-convertr --nip5 satoshivibes.com
lukeonchain,npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k
```
- or you can do multiple domains at once
```shell
$> key-convertr --nip5 satoshivibes.com,nostrplebs.com,strike.me
jack,npub1cn4t4cd78nm900qc2hhqte5aa8c9njm6qkfzw95tszufwcwtcnsq7g3vle
lukeonchain,npub138guayty78ch9k42n3uyz5ch3jcaa3u390647hwq0c83m2lypekq6wk36k
zwartwitzwaan,npub1t4n7gac8dznpnl8wk46arq2k0vnz3f7cwfvvtre2rv7n9kw9a4cstkm262
zyl,npub16zmhar4qrw4hja9uxeu7ms0pxkwft6459klg7w6xfpvqnsgaha2q6kdtav
zzar,npub1egways3vh9y8fstxdjw8ddukrwaw5sexxfjr773de82d90antkussd6l5z
...
...
...
```
- you can also enable NIP5 related stats via "--nip-stats" or "-s";
    - this prints out summary stats in this format: `domain=SomeName.com|count=21`
    - this output could then be parsed (if needed) by other dev tools/libraries
```shell
$> key-convertr --nip5 strike.me --nip-stats
Zaxounette,npub13w02l37gkjwv90lnklfet5653jj0p5ueu976v3dpda5afvxgw3uslcqdnv
cory,npub1dpca3hcdgfdzkplvmsc28dfllth3fkddy4elc92zd9xk2j5njmqsxraun7
ivan,npub10djxr5pvdu97rjkde7tgcsjxzpdzmdguwacfjwlchvj7t88dl7nsdl54nf
jack,npub1cn4t4cd78nm900qc2hhqte5aa8c9njm6qkfzw95tszufwcwtcnsq7g3vle
jespada,npub1747ceatm52f6wexdxre5v88zrv9rsjw9cq6nxwg6zp6yzfsz7lysxd4uzf
manuela,npub1w0s7l9ek32zry7ecn6n0gw4ucg8krzmu9sp3fmhuggjftsqsm3lqns60a6
marfusios,npub1dd668dyr9un9nzf9fjjkpdcqmge584c86gceu7j97nsp4lj2pscs0xk075
matt,npub10p2acl6yd40zu7uu95y496wetwpvepxy4vr9dj74g790d7plht8q73wjkx
mattyp,npub1y7thlx9gxmv57zq3gy7k8z0yxczqf0ngsvdh6m0cgpt4c8qug5wscm350a
mrfelton,npub13zrk607qzmzve7nlmalnl0suealcqt8nxucmhvasgywk4zd40j9qs2lmne
packetprotector,npub1e7vyw7vtycrphmch5gna4yez8jhaj5ush4pyu9pd5qrwfvgpznhqsttv8r
rockstar,npub1j8y6tcdfw3q3f3h794s6un0gyc5742s0k5h5s2yqj0r70cpklqeqjavrvg
stross,npub13rrhlf0zek4n6y5f0axw4zhqpppnwnjfh5vhusq3arvnd9vtz07sjh37nr
szollo,npub100n0yahp4kan33pz3htw5e5qegs3t5umesesjp9ycz3l4xpwawws988nqc
verbiricha,npub107jk7htfv243u0x5ynn43scq9wrxtaasmrwwa8lfu2ydwag6cx2quqncxg
domain=strike.me|count=15
```

Updated error messaging looks like this (prettier error messaging - and de-clutters the main())
![image](https://user-images.githubusercontent.com/72365181/217449162-3b292fde-b464-4f1a-a06e-c3cc39ae55ad.png)
![image](https://user-images.githubusercontent.com/72365181/217449201-635e006c-77cf-461f-a5d8-de374649ad63.png)
![image](https://user-images.githubusercontent.com/72365181/217449232-962219d1-180e-4fd1-b335-0ff25ebd7ae7.png)